### PR TITLE
fix: return empty arrays for search API

### DIFF
--- a/cmd/food-recipes/server.go
+++ b/cmd/food-recipes/server.go
@@ -35,7 +35,16 @@ func serve(db *DB, gs *GlyphStore, addr string) error {
 		}
 		parts := splitCSVLike(have)
 		mapped, unknown := db.mapUserIngredients(parts)
+		if mapped == nil {
+			mapped = []string{}
+		}
+		if unknown == nil {
+			unknown = []string{}
+		}
 		sugs := db.suggest(mapped)
+		if sugs == nil {
+			sugs = []Recipe{}
+		}
 
 		resp := apiResp{
 			Mapped:       mapped,


### PR DESCRIPTION
## Summary
- avoid `null` values in `/api/suggest` response
- ensure suggestions endpoint always returns arrays

## Testing
- `go vet ./...`
- `go build ./cmd/food-recipes`
- `curl -s 'http://localhost:8092/api/suggest?have=Chromatic%20Metal'`
- `curl -s 'http://localhost:8092/api/suggest?have=Foo'`


------
https://chatgpt.com/codex/tasks/task_e_68c74344770083319334e875a44abbbd