### PR TITLE
Add refiner recipes page and navigation

### DIFF
--- a/cmd/food-recipes/main.go
+++ b/cmd/food-recipes/main.go
@@ -9,18 +9,25 @@ import (
 // ---------- Main ----------
 
 func main() {
-	var csvPath string
+	var foodPath string
+	var refinerPath string
 	var addr string
 	var glyphPath string
 
-	flag.StringVar(&csvPath, "csv", "food.csv", "Path to food.csv (recipe table)")
+	flag.StringVar(&foodPath, "csv", "food.csv", "Path to food.csv (recipe table)")
+	flag.StringVar(&refinerPath, "refiner", "refiner.csv", "Path to refiner.csv (recipe table)")
 	flag.StringVar(&addr, "addr", ":8080", "Listen address")
 	flag.StringVar(&glyphPath, "glyphs", "glyphs.json", "Path to glyphs JSON file")
 	flag.Parse()
 
-	if !filepath.IsAbs(csvPath) {
-		if abs, err := filepath.Abs(csvPath); err == nil {
-			csvPath = abs
+	if !filepath.IsAbs(foodPath) {
+		if abs, err := filepath.Abs(foodPath); err == nil {
+			foodPath = abs
+		}
+	}
+	if !filepath.IsAbs(refinerPath) {
+		if abs, err := filepath.Abs(refinerPath); err == nil {
+			refinerPath = abs
 		}
 	}
 	if !filepath.IsAbs(glyphPath) {
@@ -29,12 +36,20 @@ func main() {
 		}
 	}
 
-	db, err := loadCSV(csvPath)
+	foodDB, err := loadCSV(foodPath)
 	if err != nil {
-		log.Fatalf("load csv: %v", err)
+		log.Fatalf("load food csv: %v", err)
 	}
-	if len(db.Recipes) == 0 {
-		log.Fatalf("no recipes parsed from %s", csvPath)
+	if len(foodDB.Recipes) == 0 {
+		log.Fatalf("no recipes parsed from %s", foodPath)
+	}
+
+	refDB, err := loadCSV(refinerPath)
+	if err != nil {
+		log.Fatalf("load refiner csv: %v", err)
+	}
+	if len(refDB.Recipes) == 0 {
+		log.Fatalf("no refiner recipes parsed from %s", refinerPath)
 	}
 
 	gs := &GlyphStore{Path: glyphPath}
@@ -42,10 +57,11 @@ func main() {
 		log.Fatalf("load glyphs: %v", err)
 	}
 
-	log.Printf("recipes: %d | ingredients: %d | csv: %s", len(db.Recipes), len(db.AllIngredients), csvPath)
+	log.Printf("food recipes: %d | ingredients: %d | csv: %s", len(foodDB.Recipes), len(foodDB.AllIngredients), foodPath)
+	log.Printf("refiner recipes: %d | ingredients: %d | csv: %s", len(refDB.Recipes), len(refDB.AllIngredients), refinerPath)
 	log.Printf("glyphs: %d | file: %s", len(gs.Items), glyphPath)
 
-	if err := serve(db, gs, addr); err != nil {
+	if err := serve(foodDB, refDB, gs, addr); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/food-recipes/templates.go
+++ b/cmd/food-recipes/templates.go
@@ -9,6 +9,7 @@ import (
 var tmplFS embed.FS
 
 var (
-	indexTmpl  = template.Must(template.ParseFS(tmplFS, "templates/index.html"))
-	glyphsTmpl = template.Must(template.ParseFS(tmplFS, "templates/glyphs.html"))
+	indexTmpl   = template.Must(template.ParseFS(tmplFS, "templates/index.html"))
+	refinerTmpl = template.Must(template.ParseFS(tmplFS, "templates/refiner.html"))
+	glyphsTmpl  = template.Must(template.ParseFS(tmplFS, "templates/glyphs.html"))
 )

--- a/cmd/food-recipes/templates/glyphs.html
+++ b/cmd/food-recipes/templates/glyphs.html
@@ -148,6 +148,7 @@ textarea.inputGlass{ min-height:70px; resize:vertical }
 </div>
 <nav class="dock" role="navigation" aria-label="Primary">
   <a class="dock-btn" href="/"><span class="dock-ico">🏠</span><span class="label">Home</span></a>
+  <a class="dock-btn" href="/refiner"><span class="dock-ico">⚗️</span><span class="label">Refiner</span></a>
   <a class="dock-btn active" href="/glyphs"><span class="dock-ico">🔤</span><span class="label">Glyphs</span></a>
 </nav>
 <script>

--- a/cmd/food-recipes/templates/refiner.html
+++ b/cmd/food-recipes/templates/refiner.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Nirvana Recipe Finder</title>
+<title>Nirvana Refiner Recipes</title>
 <style>
 :root{
   --mint-25:#daf7ee; --mint-50:#c6f2e6; --mint-100:#a2ecd9;
@@ -131,7 +131,7 @@ kbd{ background:rgba(53,217,179,0.20); border-radius:6px; border:1px solid rgba(
   <div class="card">
     <div class="header">
       <span class="badge">Nirvana</span>
-      <h1>Recipe Finder</h1>
+      <h1>Refiner Recipes</h1>
     </div>
     <div class="sub">Type one or more ingredients. Press <strong>Enter</strong> to add; with the input empty, <strong>Enter</strong> searches.</div>
     <div class="inputRow">
@@ -155,8 +155,8 @@ kbd{ background:rgba(53,217,179,0.20); border-radius:6px; border:1px solid rgba(
   </div>
 </div>
 <nav class="dock" role="navigation" aria-label="Primary">
-  <a class="dock-btn active" href="/"><span class="dock-ico">🏠</span><span class="label">Home</span></a>
-  <a class="dock-btn" href="/refiner"><span class="dock-ico">⚗️</span><span class="label">Refiner</span></a>
+  <a class="dock-btn" href="/"><span class="dock-ico">🏠</span><span class="label">Home</span></a>
+  <a class="dock-btn active" href="/refiner"><span class="dock-ico">⚗️</span><span class="label">Refiner</span></a>
   <a class="dock-btn" href="/glyphs"><span class="dock-ico">🔤</span><span class="label">Glyphs</span></a>
 </nav>
 <script>
@@ -283,14 +283,14 @@ function renderChips(arr){
 }
 async function fetchIngredients(){
   try{
-    const r = await fetch('/api/ingredients');
+    const r = await fetch('/api/refiner/ingredients');
     if(!r.ok) throw new Error('load failed');
     return await r.json();
   }catch{ return []; }
 }
 async function suggest(){
   try{
-    const r = await fetch('/api/suggest?have=' + encodeURIComponent(tokens.join(',')));
+    const r = await fetch('/api/refiner/suggest?have=' + encodeURIComponent(tokens.join(',')));
     if(!r.ok) throw new Error('suggest failed');
     const data = await r.json();
     handleSuggestResp(data);


### PR DESCRIPTION
## Summary
- add `/refiner` page backed by new refiner.csv data
- expose refiner suggestion and ingredients APIs and route
- update floating dock with Refiner link on all pages

## Testing
- `go build ./...`
- `go vet ./cmd/food-recipes/...`


------
https://chatgpt.com/codex/tasks/task_e_68c745b8cb44833183fa5e7be544c810